### PR TITLE
install-zhiverbox.sh: allow scrollback after clear

### DIFF
--- a/install-zHIVErbox.sh
+++ b/install-zHIVErbox.sh
@@ -146,7 +146,7 @@ press_any_key()
 
 new_screen()
 {
-    echo "" && clear
+    echo "" && clear -x
 }
 
 press_any_key_for_new_screen()
@@ -2252,7 +2252,7 @@ press_any_key
 
 # customization complete
 echo ""
-clear
+clear -x
 display_alert "$PROJNAME image customization complete!" "$SRC/$DEST_IMAGE_NAME" "ext"
 echo ""
 display_alert "Flash this image to a SD card with Etcher now!" "https://etcher.io/" "todo"


### PR DESCRIPTION
It's quite annoying that you can't scroll back in the output of this script. I think there's no specific reason as no confidential information (e.g. private keys) are shown. The `-x` option of the `clear` command fixes this.